### PR TITLE
Quick fix to a bug in the filters.

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -22,11 +22,12 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 			$terms_filtered = is_array( $terms ) ? array_filter( $terms ) : array();
 
 			return array(
-				$tax . '_name' => $terms_filtered
+				$tax => $terms_filtered
 			);
 		}
 
 		public static function get_news_items( $args ) {
+			
 			$args = array(
 				'url'        => get_option( 'ucf_news_feed_url', 'https://today.ucf.edu/wp-json/wp/v2/' ),
 				'limit'      => isset( $args['limit'] ) ? (int) $args['limit'] : 3,

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -75,8 +75,8 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 			$layout = $attr['layout'];
 
 			$args = array(
-				'sections' => $attr['sections'] ? explode( ',', $attr['sections'] ) : null,
-				'topics'   => $attr['topics'] ? explode( ',', $attr['topics'] ) : null,
+				'sections' => $attr['sections'] ?: null,
+				'topics'   => $attr['topics'] ?: null,
 				'offset'   => $attr['offset'] ? (int) $attr['offset'] : 0,
 				'limit'    => $attr['limit'] ? (int) $attr['limit'] : 3
 			);

--- a/includes/ucf-news-widget.php
+++ b/includes/ucf-news-widget.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'UCF_News_Widget' ) ) {
 		?>
 			<aside class="widget ucf-news-widget">
 		<?php
-			UCF_News_Common::display_news_items( $items, $layout, $title, 'widget' );
+			echo UCF_News_Common::display_news_items( $items, $layout, $title, 'widget' );
 		?>
 			</aside>
 		<?php


### PR DESCRIPTION
The filter[_parameter_] expects either `tag` or `category` and doesn't appear to like `tag_name` or `category_name`. This might be related to a change in the way WP_REST_API works. Will look into it.