### PR TITLE
Feed Update

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -6,7 +6,7 @@
 if ( ! class_exists( 'UCF_News_Feed' ) ) {
 	class UCF_News_Feed {
 		public static function get_json_feed( $feed_url ) {
-			$response = wp_safe_remote_get( $feed_url, array( 'timeout' => 15 ) );
+			$response = wp_remote_get( $feed_url, array( 'timeout' => 15 ) );
 
 			if ( is_array( $response ) && wp_remote_retrieve_response_code( $response ) == 200 ) {
 				$result = json_decode( wp_remote_retrieve_body( $response ) );

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,27 @@ TODO
 
 ## Changelog ##
 
-### 1.0 ###
+### 1.0.4 ###
+
+* Bug Fixes:
+  * Updates the way the news feed is pulled to prevent error when accessing external host.
+
+### 1.0.3 ###
+
+* Enhancements: 
+  * Adds empty alt tag to classic layout images for accessibility.
+
+### 1.0.2 ###
+
+* Bug Fixes:
+  * Corrects filter name from category to category_name.
+
+### 1.0.1 ###
+
+* Bug Fixes:
+  * Corrects a bug with sections and topics filters.
+
+### 1.0.0 ###
 * Initial release
 
 

--- a/ucf-news.php
+++ b/ucf-news.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: UCF News
 Description: Contains shortcode and widget for displaying UCF News Feeds
-Version: 1.0.1
+Version: 1.0.4
 Author: UCF Web Communications
 License: GPL3
 */


### PR DESCRIPTION
Updated function that pulls news items to use `wp_remote_get` since the url being passed is not arbitrary, and doesn't require the same level of validation.