### PR TITLE
Updated feed to use news query params for UCF Today

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -6,7 +6,7 @@
 if ( ! class_exists( 'UCF_News_Feed' ) ) {
 	class UCF_News_Feed {
 		public static function get_json_feed( $feed_url ) {
-			$response = wp_safe_remote_get( $feed_url, array( 'timeout' => 15 ) );
+			$response = wp_remote_get( $feed_url, array( 'timeout' => 15 ) );
 
 			if ( is_array( $response ) && wp_remote_retrieve_response_code( $response ) == 200 ) {
 				$result = json_decode( wp_remote_retrieve_body( $response ) );

--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -19,11 +19,9 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 		}
 
 		public static function format_tax_arg( $terms, $tax ) {
-			$terms_filtered = is_array( $terms ) ? array_filter( $terms ) : array();
+			$terms_filtered = is_array( $terms ) ? array_filter( $terms ) : null;
 
-			return array(
-				$tax => $terms_filtered
-			);
+			return $terms_filtered;
 		}
 
 		public static function get_news_items( $args ) {
@@ -47,21 +45,21 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 			$categories = $tags = array();
 
 			if ( isset( $args['categories'] ) ) {
-				$categories = self::format_tax_arg( $args['categories'], 'category_name' );
+				$categories = self::format_tax_arg( $args['categories'], 'category_slugs' );
 			}
 			if ( isset( $args['tags'] ) ) {
-				$tags = self::format_tax_arg( $args['tags'], 'tag' );
+				$tags = self::format_tax_arg( $args['tags'], 'tag_slugs' );
 			}
 
-			$filter = array_merge( $categories, $tags );
-
 			$query = http_build_query( array(
-				'per_page'   => $args['limit'],
-				'offset'     => $args['offset'],
-				'filter'     => $filter,
+				'per_page'       => $args['limit'],
+				'offset'         => $args['offset'],
+				'category_slugs' => $categories,
+				'tag_slugs'      => $tags,
 				'_embed'     => true
 			) );
-			$query = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query );
+			//$query = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query );
+			$query = preg_replace( '/%5B[0-9]+%5D/simU', '%5B%5D', $query );
 
 			// Fetch feed
 			$feed_url = $args['url'] . 'posts?' . $query;

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,27 @@ TODO
 
 ## Changelog ##
 
-### 1.0 ###
+### 1.0.4 ###
+
+* Bug Fixes:
+  * Updates the way the news feed is pulled to prevent error when accessing external host.
+
+### 1.0.3 ###
+
+* Enhancements: 
+  * Adds empty alt tag to classic layout images for accessibility.
+
+### 1.0.2 ###
+
+* Bug Fixes:
+  * Corrects filter name from category to category_name.
+
+### 1.0.1 ###
+
+* Bug Fixes:
+  * Corrects a bug with sections and topics filters.
+
+### 1.0.0 ###
 * Initial release
 
 

--- a/ucf-news.php
+++ b/ucf-news.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: UCF News
 Description: Contains shortcode and widget for displaying UCF News Feeds
-Version: 1.0.1
+Version: 1.0.4
 Author: UCF Web Communications
 License: GPL3
 */


### PR DESCRIPTION
Resolves Issue #5. This change will require a minor version change, as the new logic depends on the `category_slugs` and `tag_slugs` parameters being on today.ucf.edu.