### PR TITLE
URL no longer defaults to empty if an 'empty value' is saved on the settings page.

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -25,9 +25,11 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 		}
 
 		public static function get_news_items( $args ) {
+			
+			$url_option = get_option('ucf_news_feed_url');
 
 			$args = array(
-				'url'        => get_option( 'ucf_news_feed_url', 'https://today.ucf.edu/wp-json/wp/v2/' ),
+				'url'        => $url_option ? $url_option : 'https://today.ucf.edu/wp-json/wp/v2/',
 				'limit'      => isset( $args['limit'] ) ? (int) $args['limit'] : 3,
 				'offset'     => isset( $args['offset'] ) ? (int) $args['offset'] : 0,
 				'categories' => isset( $args['sections'] ) ? explode( ',', $args['sections'] ) : null,


### PR DESCRIPTION
Steps to replicate the bug:

1) Run the current version of the plugin (1.1.0).
2) Go to UCF News Settings and click "Save Changes" without making any
changes (so "URL" should be an empty text field).
3) Watch the widget render nothing because the get_option() default only
kicks in if the value doesn't exist.