### PR TITLE
Notice fixes

### DIFF
--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -6,7 +6,7 @@
 if ( ! class_exists( 'UCF_News_Common' ) ) {
 
 	class UCF_News_Common {
-		public function display_news_items( $items, $layout, $title, $per_row, $display_type='default' ) {
+		public static function display_news_items( $items, $layout, $title, $per_row, $display_type='default' ) {
 			ob_start();
 
 			if ( has_action( 'ucf_news_display_' . $layout . '_before' ) ) {

--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -24,9 +24,16 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 			return $terms_filtered;
 		}
 
+		public static function non_empty_allow_zero( $arg ) {
+			return !(
+				is_array( $arg ) && empty( $arg )
+				|| is_null( $arg )
+				|| is_string( $arg ) && empty( $arg )
+			);
+		}
+
 		public static function get_news_items( $args ) {
-			
-			$url_option = get_option('ucf_news_feed_url');
+			$url_option = get_option( 'ucf_news_feed_url' );
 
 			$args = array(
 				'url'        => $url_option ? $url_option : 'https://today.ucf.edu/wp-json/wp/v2/',
@@ -37,11 +44,7 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 			);
 
 			// Empty array of indexes with no value.
-			$keys = array_keys( $args, NULL );
-
-			foreach( $keys as $key ) {
-				unset( $args[$key] );
-			}
+			$args = array_filter( $args, array( 'UCF_News_Feed', 'non_empty_allow_zero' ) );
 
 			// Set up query params.
 			$categories = $tags = array();


### PR DESCRIPTION
- Fixed `display_news_items()` in `UCF_News_Common` not being declared as a static method
- Updated filtering of options in `UCF_News_Feed::get_news_items()` to allow 0 values.  Fixes an issue where, when set to 0, 'limit' or 'offset' would be unset, causing undefined index notices when referenced in `http_build_query()`.