### PR TITLE
Filters

### DIFF
--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -9,21 +9,39 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 		public static function display_news_items( $items, $layout, $title, $per_row, $display_type='default' ) {
 			ob_start();
 
-			if ( has_action( 'ucf_news_display_' . $layout . '_before' ) ) {
-				do_action( 'ucf_news_display_' . $layout . '_before', $items, $title, $display_type );
+			// Before
+			$layout_before = ucf_news_display_classic_before( $items, $title, $display_type );
+			if ( has_filter( 'ucf_news_display_' . $layout . '_before' ) ) {
+				$layout_before = apply_filters( 'ucf_news_display_' . $layout . '_before', $layout_before, $items, $title, $display_type );
 			}
+			echo $layout_before;
 
-			if ( has_action( 'ucf_news_display_' . $layout . '_title' ) ) {
-				do_action( 'ucf_news_display_' . $layout . '_title', $items, $title, $display_type );
+			// Title
+			$layout_title = ucf_news_display_classic_title( $items, $title, $display_type );
+			if ( has_filter( 'ucf_news_display_' . $layout . '_title' ) ) {
+				$layout_title = apply_filters( 'ucf_news_display_' . $layout . '_title', $layout_title, $items, $title, $display_type );
 			}
+			echo $layout_title;
 
-			if ( has_action( 'ucf_news_display_' . $layout  ) ) {
-				do_action( 'ucf_news_display_' . $layout, $items, $title, $per_row, $display_type );
+			// Main content/loop
+			$layout_content = ucf_news_display_classic( $items, $title, $display_type );
+			if ( has_filter( 'ucf_news_display_' . $layout ) ) {
+				// Special exception for card layout, which requires 4 args
+				if ( $layout === 'card' ) {
+					$layout_content = apply_filters( 'ucf_news_display_' . $layout, $layout_content, $items, $title, $per_row, $display_type );
+				}
+				else {
+					$layout_content = apply_filters( 'ucf_news_display_' . $layout, $layout_content, $items, $title, $display_type );
+				}
 			}
+			echo $layout_content;
 
-			if ( has_action( 'ucf_news_display_' . $layout . '_after' ) ) {
-				do_action( 'ucf_news_display_' . $layout . '_after', $items, $title, $display_type );
+			// After
+			$layout_after = ucf_news_display_classic_after( $items, $title, $display_type );
+			if ( has_filter( 'ucf_news_display_' . $layout . '_after' ) ) {
+				$layout_after = apply_filters( 'ucf_news_display_' . $layout . '_after', $layout_after, $items, $title, $display_type );
 			}
+			echo $layout_after;
 
 			return ob_get_clean();
 		}

--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -6,40 +6,34 @@
 if ( ! class_exists( 'UCF_News_Common' ) ) {
 
 	class UCF_News_Common {
-		public static function display_news_items( $items, $layout, $title, $per_row, $display_type='default' ) {
+		public static function display_news_items( $items, $layout, $args, $display_type='default' ) {
 			ob_start();
 
 			// Before
-			$layout_before = ucf_news_display_classic_before( '', $items, $title, $display_type );
+			$layout_before = ucf_news_display_classic_before( '', $items, $args, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_before' ) ) {
-				$layout_before = apply_filters( 'ucf_news_display_' . $layout . '_before', $layout_before, $items, $title, $display_type );
+				$layout_before = apply_filters( 'ucf_news_display_' . $layout . '_before', $layout_before, $items, $args, $display_type );
 			}
 			echo $layout_before;
 
 			// Title
-			$layout_title = ucf_news_display_classic_title( '', $items, $title, $display_type );
+			$layout_title = ucf_news_display_classic_title( '', $items, $args, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_title' ) ) {
-				$layout_title = apply_filters( 'ucf_news_display_' . $layout . '_title', $layout_title, $items, $title, $display_type );
+				$layout_title = apply_filters( 'ucf_news_display_' . $layout . '_title', $layout_title, $items, $args, $display_type );
 			}
 			echo $layout_title;
 
 			// Main content/loop
-			$layout_content = ucf_news_display_classic( '', $items, $title, $display_type );
+			$layout_content = ucf_news_display_classic( '', $items, $args, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout ) ) {
-				// Special exception for card layout, which requires 4 args
-				if ( $layout === 'card' ) {
-					$layout_content = apply_filters( 'ucf_news_display_' . $layout, $layout_content, $items, $title, $per_row, $display_type );
-				}
-				else {
-					$layout_content = apply_filters( 'ucf_news_display_' . $layout, $layout_content, $items, $title, $display_type );
-				}
+				$layout_content = apply_filters( 'ucf_news_display_' . $layout, $layout_content, $items, $args, $display_type );
 			}
 			echo $layout_content;
 
 			// After
-			$layout_after = ucf_news_display_classic_after( '', $items, $title, $display_type );
+			$layout_after = ucf_news_display_classic_after( '', $items, $args, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_after' ) ) {
-				$layout_after = apply_filters( 'ucf_news_display_' . $layout . '_after', $layout_after, $items, $title, $display_type );
+				$layout_after = apply_filters( 'ucf_news_display_' . $layout . '_after', $layout_after, $items, $args, $display_type );
 			}
 			echo $layout_after;
 

--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -10,21 +10,21 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 			ob_start();
 
 			// Before
-			$layout_before = ucf_news_display_classic_before( $items, $title, $display_type );
+			$layout_before = ucf_news_display_classic_before( '', $items, $title, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_before' ) ) {
 				$layout_before = apply_filters( 'ucf_news_display_' . $layout . '_before', $layout_before, $items, $title, $display_type );
 			}
 			echo $layout_before;
 
 			// Title
-			$layout_title = ucf_news_display_classic_title( $items, $title, $display_type );
+			$layout_title = ucf_news_display_classic_title( '', $items, $title, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_title' ) ) {
 				$layout_title = apply_filters( 'ucf_news_display_' . $layout . '_title', $layout_title, $items, $title, $display_type );
 			}
 			echo $layout_title;
 
 			// Main content/loop
-			$layout_content = ucf_news_display_classic( $items, $title, $display_type );
+			$layout_content = ucf_news_display_classic( '', $items, $title, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout ) ) {
 				// Special exception for card layout, which requires 4 args
 				if ( $layout === 'card' ) {
@@ -37,7 +37,7 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 			echo $layout_content;
 
 			// After
-			$layout_after = ucf_news_display_classic_after( $items, $title, $display_type );
+			$layout_after = ucf_news_display_classic_after( '', $items, $title, $display_type );
 			if ( has_filter( 'ucf_news_display_' . $layout . '_after' ) ) {
 				$layout_after = apply_filters( 'ucf_news_display_' . $layout . '_after', $layout_after, $items, $title, $display_type );
 			}

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 			ob_start();
 
 			if ( $items ) {
-				echo UCF_News_Common::display_news_items( $items, $layout, $title, $per_row, 'default' );
+				echo UCF_News_Common::display_news_items( $items, $layout, array_merge( $attr, $args ), 'default' );
 			}
 
 			return ob_get_clean();

--- a/includes/ucf-news-widget.php
+++ b/includes/ucf-news-widget.php
@@ -32,14 +32,16 @@ if ( ! class_exists( 'UCF_News_Widget' ) ) {
 			$offset = (int) $instance['offset'];
 			$layout = $instance['layout'];
 
-			$items = UCF_News_Feed::get_news_items( array(
+			$items_args = array(
 				'title'    => $title,
 				'sections' => $sections,
 				'topics'   => $topics,
 				'limit'    => $limit,
 				'offset'   => $offset,
-				'per_row'   => $per_row
-			) );
+				'per_row'  => $per_row
+			);
+
+			$items = UCF_News_Feed::get_news_items( $items_args );
 
 			ob_start();
 
@@ -47,7 +49,7 @@ if ( ! class_exists( 'UCF_News_Widget' ) ) {
 		?>
 			<aside class="widget ucf-news-widget">
 		<?php
-			echo UCF_News_Common::display_news_items( $items, $layout, $title, $per_row, 'widget' );
+			echo UCF_News_Common::display_news_items( $items, $layout, $items_args, 'widget' );
 		?>
 			</aside>
 		<?php

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -8,10 +8,10 @@ if ( ! function_exists( 'ucf_news_display_card_before' ) ) {
 	?>
 		<div class="ucf-news card-layout">
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_card_before', 'ucf_news_display_card_before', 10, 3 );
+	add_filter( 'ucf_news_display_card_before', 'ucf_news_display_card_before', 10, 3 );
 }
 
 if ( ! function_exists( 'ucf_news_display_card_title' ) ) {
@@ -29,10 +29,10 @@ if ( ! function_exists( 'ucf_news_display_card_title' ) ) {
 				break;
 		}
 
-		echo $formatted_title;
+		return $formatted_title;
 	}
 
-	add_action( 'ucf_news_display_card_title', 'ucf_news_display_card_title', 10, 3 );
+	add_filter( 'ucf_news_display_card_title', 'ucf_news_display_card_title', 10, 3 );
 }
 
 if ( ! function_exists( 'ucf_news_display_card' ) ) {
@@ -65,20 +65,20 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 
 		echo '</div>';
 
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_card', 'ucf_news_display_card', 10, 4 );
+	add_filter( 'ucf_news_display_card', 'ucf_news_display_card', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_card_after' ) ) {
-	function ucf_news_display_card_after( $items, $title, $display_type ) {
+	function ucf_news_display_card_after( $content, $items, $title, $display_type ) {
 		ob_start();
 	?>
 		</div>
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_card_after', 'ucf_news_display_card_after', 10, 3 );
+	add_filter( 'ucf_news_display_card_after', 'ucf_news_display_card_after', 10, 3 );
 }

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -3,7 +3,7 @@
  * The default functions for the card layout
  **/
 if ( ! function_exists( 'ucf_news_display_card_before' ) ) {
-	function ucf_news_display_card_before( $items, $title, $display_type ) {
+	function ucf_news_display_card_before( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		<div class="ucf-news card-layout">
@@ -11,20 +11,20 @@ if ( ! function_exists( 'ucf_news_display_card_before' ) ) {
 		return ob_get_clean();
 	}
 
-	add_filter( 'ucf_news_display_card_before', 'ucf_news_display_card_before', 10, 3 );
+	add_filter( 'ucf_news_display_card_before', 'ucf_news_display_card_before', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_card_title' ) ) {
-	function ucf_news_display_card_title( $item, $title, $display_type ) {
-		$formatted_title = $title;
+	function ucf_news_display_card_title( $content, $items, $args, $display_type ) {
+		$formatted_title = $args['title'];
 
 		switch( $display_type ) {
 			case 'widget':
 				break;
 			case 'default':
 			default:
-				if ( $title ) {
-					$formatted_title = '<h2 class="ucf-news-title">' . $title . '</h2>';
+				if ( $formatted_title ) {
+					$formatted_title = '<h2 class="ucf-news-title">' . $formatted_title . '</h2>';
 				}
 				break;
 		}
@@ -32,19 +32,21 @@ if ( ! function_exists( 'ucf_news_display_card_title' ) ) {
 		return $formatted_title;
 	}
 
-	add_filter( 'ucf_news_display_card_title', 'ucf_news_display_card_title', 10, 3 );
+	add_filter( 'ucf_news_display_card_title', 'ucf_news_display_card_title', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_card' ) ) {
-	function ucf_news_display_card( $items, $title, $per_row, $display_type ) {
+	function ucf_news_display_card( $content, $items, $args, $display_type ) {
 		if ( ! is_array( $items ) ) { $items = array( $items ); }
+		$per_row = $args['per_row'];
+
 		ob_start();
 
 		echo '<div class="ucf-news-card-deck">';
 
-		foreach( $items as $index=>$item ) :
-		$date = date("M d",strtotime($item->date));
-		$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
+		foreach ( $items as $index=>$item ) :
+			$date = date( "M d", strtotime( $item->date ) );
+			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
 	?>
 		<?php
 			if( $index !== 0 && ( $index % $per_row ) === 0 ) {
@@ -72,7 +74,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_card_after' ) ) {
-	function ucf_news_display_card_after( $content, $items, $title, $display_type ) {
+	function ucf_news_display_card_after( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		</div>
@@ -80,5 +82,5 @@ if ( ! function_exists( 'ucf_news_display_card_after' ) ) {
 		return ob_get_clean();
 	}
 
-	add_filter( 'ucf_news_display_card_after', 'ucf_news_display_card_after', 10, 3 );
+	add_filter( 'ucf_news_display_card_after', 'ucf_news_display_card_after', 10, 4 );
 }

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -3,7 +3,7 @@
  * The default functions for the classic layout
  **/
 if ( ! function_exists( 'ucf_news_display_classic_before' ) ) {
-	function ucf_news_display_classic_before( $content, $items, $title, $display_type ) {
+	function ucf_news_display_classic_before( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		<div class="ucf-news classic">
@@ -15,16 +15,16 @@ if ( ! function_exists( 'ucf_news_display_classic_before' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_classic_title' ) ) {
-	function ucf_news_display_classic_title( $content, $items, $title, $display_type ) {
-		$formatted_title = $title;
+	function ucf_news_display_classic_title( $content, $items, $args, $display_type ) {
+		$formatted_title = $args['title'];
 
 		switch( $display_type ) {
 			case 'widget':
 				break;
 			case 'default':
 			default:
-				if ( $title ) {
-					$formatted_title = '<h2 class="ucf-news-title">' . $title . '</h2>';
+				if ( $formatted_title ) {
+					$formatted_title = '<h2 class="ucf-news-title">' . $formatted_title . '</h2>';
 				}
 				break;
 		}
@@ -36,7 +36,7 @@ if ( ! function_exists( 'ucf_news_display_classic_title' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_classic' ) ) {
-	function ucf_news_display_classic( $content, $items, $title, $display_type ) {
+	function ucf_news_display_classic( $content, $items, $args, $display_type ) {
 		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
@@ -69,7 +69,7 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_classic_after' ) ) {
-	function ucf_news_display_classic_after( $content, $items, $title, $display_type ) {
+	function ucf_news_display_classic_after( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		</div>

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -3,19 +3,19 @@
  * The default functions for the classic layout
  **/
 if ( ! function_exists( 'ucf_news_display_classic_before' ) ) {
-	function ucf_news_display_classic_before( $items, $title, $display_type ) {
+	function ucf_news_display_classic_before( $content, $items, $title, $display_type ) {
 		ob_start();
 	?>
 		<div class="ucf-news classic">
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_classic_before', 'ucf_news_display_classic_before', 10, 3 );
+	add_filter( 'ucf_news_display_classic_before', 'ucf_news_display_classic_before', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_classic_title' ) ) {
-	function ucf_news_display_classic_title( $item, $title, $display_type) {
+	function ucf_news_display_classic_title( $content, $items, $title, $display_type ) {
 		$formatted_title = $title;
 
 		switch( $display_type ) {
@@ -29,14 +29,14 @@ if ( ! function_exists( 'ucf_news_display_classic_title' ) ) {
 				break;
 		}
 
-		echo $formatted_title;
+		return $formatted_title;
 	}
 
-	add_action( 'ucf_news_display_classic_title', 'ucf_news_display_classic_title', 10, 3 );
+	add_filter( 'ucf_news_display_classic_title', 'ucf_news_display_classic_title', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_classic' ) ) {
-	function ucf_news_display_classic( $items, $title, $display_type ) {
+	function ucf_news_display_classic( $content, $items, $title, $display_type ) {
 		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 	?>
@@ -62,20 +62,20 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 	?>
 	</div>
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_classic', 'ucf_news_display_classic', 10, 3 );
+	add_filter( 'ucf_news_display_classic', 'ucf_news_display_classic', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_classic_after' ) ) {
-	function ucf_news_display_classic_after( $items, $title, $display_type ) {
+	function ucf_news_display_classic_after( $content, $items, $title, $display_type ) {
 		ob_start();
 	?>
 		</div>
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_classic_after', 'ucf_news_display_classic_after', 10, 3 );
+	add_filter( 'ucf_news_display_classic_after', 'ucf_news_display_classic_after', 10, 4 );
 }

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -3,19 +3,19 @@
  * The default functions for the modern layout
  **/
 if ( ! function_exists( 'ucf_news_display_modern_before' ) ) {
-	function ucf_news_display_modern_before( $items, $title, $display_type ) {
+	function ucf_news_display_modern_before( $content, $items, $title, $display_type ) {
 		ob_start();
 	?>
 		<div class="ucf-news modern">
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_modern_before', 'ucf_news_display_modern_before', 10, 3 );
+	add_filter( 'ucf_news_display_modern_before', 'ucf_news_display_modern_before', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_modern_title' ) ) {
-	function ucf_news_display_modern_title( $item, $title, $display_type ) {
+	function ucf_news_display_modern_title( $content, $item, $title, $display_type ) {
 		$formatted_title = $title;
 
 		switch( $display_type ) {
@@ -29,14 +29,14 @@ if ( ! function_exists( 'ucf_news_display_modern_title' ) ) {
 				break;
 		}
 
-		echo $formatted_title;
+		return $formatted_title;
 	}
 
-	add_action( 'ucf_news_display_modern_title', 'ucf_news_display_modern_title', 10, 3 );
+	add_filter( 'ucf_news_display_modern_title', 'ucf_news_display_modern_title', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_modern' ) ) {
-	function ucf_news_display_modern( $items, $title, $display_type ) {
+	function ucf_news_display_modern( $content, $items, $title, $display_type ) {
 		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 
@@ -66,20 +66,20 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 	<?php
 		endforeach;
 
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_modern', 'ucf_news_display_modern', 10, 3 );
+	add_filter( 'ucf_news_display_modern', 'ucf_news_display_modern', 10, 4 );
 }
 
 if ( ! function_exists( 'ucf_news_display_modern_after' ) ) {
-	function ucf_news_display_modern_after( $items, $title, $display_type ) {
+	function ucf_news_display_modern_after( $content, $items, $title, $display_type ) {
 		ob_start();
 	?>
 		</div>
 	<?php
-		echo ob_get_clean();
+		return ob_get_clean();
 	}
 
-	add_action( 'ucf_news_display_modern_after', 'ucf_news_display_modern_after', 10, 3 );
+	add_filter( 'ucf_news_display_modern_after', 'ucf_news_display_modern_after', 10, 4 );
 }

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -3,7 +3,7 @@
  * The default functions for the modern layout
  **/
 if ( ! function_exists( 'ucf_news_display_modern_before' ) ) {
-	function ucf_news_display_modern_before( $content, $items, $title, $display_type ) {
+	function ucf_news_display_modern_before( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		<div class="ucf-news modern">
@@ -15,16 +15,16 @@ if ( ! function_exists( 'ucf_news_display_modern_before' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_modern_title' ) ) {
-	function ucf_news_display_modern_title( $content, $item, $title, $display_type ) {
-		$formatted_title = $title;
+	function ucf_news_display_modern_title( $content, $items, $args, $display_type ) {
+		$formatted_title = $args['title'];
 
 		switch( $display_type ) {
 			case 'widget':
 				break;
 			case 'default':
 			default:
-				if ( $title ) {
-					$formatted_title = '<h2 class="ucf-news-title">' . $title . '</h2>';
+				if ( $formatted_title ) {
+					$formatted_title = '<h2 class="ucf-news-title">' . $formatted_title . '</h2>';
 				}
 				break;
 		}
@@ -36,14 +36,14 @@ if ( ! function_exists( 'ucf_news_display_modern_title' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_modern' ) ) {
-	function ucf_news_display_modern( $content, $items, $title, $display_type ) {
+	function ucf_news_display_modern( $content, $items, $args, $display_type ) {
 		if ( ! is_array( $items ) ) { $items = array( $items ); }
 		ob_start();
 
 		foreach( $items as $item ) :
-		$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
-		$sections = UCF_News_Common::get_story_sections( $item );
-		$section = $sections[0];
+			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
+			$sections = UCF_News_Common::get_story_sections( $item );
+			$section = $sections[0];
 	?>
 		<div class="ucf-news-item">
 			<a href="<?php echo $item->link; ?>">
@@ -73,7 +73,7 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 }
 
 if ( ! function_exists( 'ucf_news_display_modern_after' ) ) {
-	function ucf_news_display_modern_after( $content, $items, $title, $display_type ) {
+	function ucf_news_display_modern_after( $content, $items, $args, $display_type ) {
 		ob_start();
 	?>
 		</div>

--- a/readme.md
+++ b/readme.md
@@ -20,13 +20,11 @@ This plugin provides a shortcode, widget, helper functions, and default styles f
 2. Configure plugin settings from the WordPress admin under "UCF News".
 
 
-## Frequently Asked Questions ##
-
-TODO
-
-
-
 ## Changelog ##
+
+### 2.0.0 ###
+* Enhancements:
+    * Updated `UCF_News_Common::display_news_items()` to render layout parts using filters instead of actions.  Please note this change is not backward-compatible with layouts registered using hooks provided by older versions of the plugin.
 
 ### 1.1.4 ###
 
@@ -91,8 +89,3 @@ None
 ## Development & Contributing ##
 
 TODO
-
-### Wishlist/TODOs ###
-* Add per-display_type hooks for modifying news list titles (instead of forcing developers to re-write all display_type use-cases in `ucf_news_display_classic_before` action)
-* Add rich snippet support, or remove references to rich snippets if this isn't desired
-* Update readme TODOs


### PR DESCRIPTION
- Updates layout parts to be rendered via filters instead of actions.  There are now defaults set for each layout part.
- Arguments passed to each filter have been consolidated-- `$title` and `$per_row` have been lumped into the `$args` array passed to each layout part.

These changes are _not_ backward-compatible with custom layouts added in themes/other plugins--hence the bumped major version for the rc branch.