### PR TITLE
Version check

### DIFF
--- a/includes/ucf-news-config.php
+++ b/includes/ucf-news-config.php
@@ -21,9 +21,45 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 				'ucf_news_http_timeout'   => 5
 			);
 
+		/**
+		 * Checks the installed version against
+		 * the version stored in a site_option
+		 */
+		public static function version_check() {
+			// Get current version in options
+			$current_version = get_option( 'ucf_news_version' );
+
+			$data = get_plugin_data( UCF_NEWS__PLUGIN_FILE, false, false );
+			$installed_version = $data['Version'];
+
+			if ( $current_version === false ) {
+				add_option( 'ucf_news_version', $installed_version );
+				self::ensure_option_defaults();
+				return;
+			}
+
+			if ( version_compare( $current_version, $installed_version, '<' ) ) {
+				self::ensure_option_defaults();
+			}
+		}
+
+		private static function ensure_option_defaults() {
+			$options = self::get_default_plugin_options();
+
+			foreach( $options as $name => $value ) {
+				$current_value = get_option( $name );
+
+				if ( $current_value === false ) {
+					add_option( $name, $value );
+				}
+			}
+		}
+
 		public static function add_options() {
 			$defaults = self::$default_plugin_options;
+			$current_version = get_option( 'ucf_news_version' );
 
+			add_option( 'ucf_news_version', $current_version );
 			add_option( 'ucf_news_feed_url', $defaults['ucf_news_feed_url'] );
 			add_option( 'ucf_news_include_css', $defaults['ucf_news_include_css'] );
 			add_option( 'ucf_news_fallback_image', $defaults['ucf_news_fallback_image'] );

--- a/includes/ucf-news-config.php
+++ b/includes/ucf-news-config.php
@@ -29,17 +29,15 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 			// Get current version in options
 			$current_version = get_option( 'ucf_news_version' );
 
-			$data = get_plugin_data( UCF_NEWS__PLUGIN_FILE, false, false );
-			$installed_version = $data['Version'];
-
 			if ( $current_version === false ) {
-				add_option( 'ucf_news_version', $installed_version );
+				add_option( 'ucf_news_version', UCF_NEWS__PLUGIN_VERSION );
 				self::ensure_option_defaults();
 				return;
 			}
 
-			if ( version_compare( $current_version, $installed_version, '<' ) ) {
+			if ( version_compare( $current_version, UCF_NEWS__PLUGIN_VERSION, '<' ) ) {
 				self::ensure_option_defaults();
+				update_option( 'ucf_news_version', UCF_NEWS__PLUGIN_VERSION );
 			}
 		}
 

--- a/ucf-news.php
+++ b/ucf-news.php
@@ -43,6 +43,8 @@ if ( ! function_exists( 'ucf_news_deactivate' ) ) {
 
 add_action( 'plugins_loaded', function() {
 
+	add_action( 'init', array( 'UCF_News_Config', 'version_check' ), 9 );
+
 	add_action( 'init', array( 'UCF_News_Shortcode', 'register_shortcode' ) );
 	add_action( 'admin_menu', array( 'UCF_News_Config', 'add_options_page' ) );
 

--- a/ucf-news.php
+++ b/ucf-news.php
@@ -11,7 +11,11 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+// Puts the info in the header above into an array.
+$data = get_plugin_data( UCF_NEWS__PLUGIN_FILE, false, false );
+
 define( 'UCF_NEWS__PLUGIN_FILE', __FILE__ );
+define( 'UCF_NEWS__PLUGIN_VERSION', $data['Version'] );
 
 require_once 'includes/ucf-news-config.php';
 require_once 'includes/ucf-news-feed.php';


### PR DESCRIPTION
Enhancements:
* Provides a method in which options can be validated whenever the plugin version changes. For example, if a new option is added between one version and the next, this would detect the version change the first time the plugin is loaded and run `ensure_option_defaults` setting a default value.

Notes:
* There may be a more efficient way of doing this, using a build number for example. Retrieving the version (by parsing the header text at the top of the root php file) and then doing the version_compare is most likely a much more expensive operation than just comparing an integer, for example, that could be set as a constant. I'm open to considering doing it a different way if we think it makes more sense to do it that way. It would just requiring us to remember to increment the constant every time we update the plugin.