### PR TITLE
Fixed handling of invalid feed results in provided news layouts

### DIFF
--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -37,7 +37,13 @@ if ( ! function_exists( 'ucf_news_display_card_title' ) ) {
 
 if ( ! function_exists( 'ucf_news_display_card' ) ) {
 	function ucf_news_display_card( $content, $items, $args, $display_type, $fallback_message='' ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
+		if ( $items === false ) {
+			$items = array();
+		}
+		else if ( ! is_array( $items ) ) {
+			$items = array( $items );
+		}
+
 		$per_row = $args['per_row'];
 
 		ob_start();

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -37,7 +37,13 @@ if ( ! function_exists( 'ucf_news_display_classic_title' ) ) {
 
 if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 	function ucf_news_display_classic( $content, $items, $args, $display_type, $fallback_message='' ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
+		if ( $items === false ) {
+			$items = array();
+		}
+		else if ( ! is_array( $items ) ) {
+			$items = array( $items );
+		}
+
 		ob_start();
 	?>
 		<div class="ucf-news-items">
@@ -55,6 +61,7 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 			<?php endif; ?>
 				<div class="ucf-news-item-title">
 					<a href="<?php echo $item->link; ?>">
+					<?php var_dump($item);?>
 						<?php echo $item->title->rendered; ?>
 					</a>
 				</div>

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -61,7 +61,6 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 			<?php endif; ?>
 				<div class="ucf-news-item-title">
 					<a href="<?php echo $item->link; ?>">
-					<?php var_dump($item);?>
 						<?php echo $item->title->rendered; ?>
 					</a>
 				</div>

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -37,7 +37,12 @@ if ( ! function_exists( 'ucf_news_display_modern_title' ) ) {
 
 if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 	function ucf_news_display_modern( $content, $items, $args, $display_type, $fallback_message ) {
-		if ( ! is_array( $items ) ) { $items = array( $items ); }
+		if ( $items === false ) {
+			$items = array();
+		}
+		else if ( ! is_array( $items ) ) {
+			$items = array( $items );
+		}
 
 		ob_start();
 


### PR DESCRIPTION
Prevent accessing non-existent object properties when feed results return `false`.