### PR TITLE
Removed unncessary logic when building query args

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -59,15 +59,13 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 				$tags = self::format_tax_arg( $args['tags'], 'tag_slugs' );
 			}
 
-			$query = http_build_query( array(
+			$query = urldecode( http_build_query( array(
 				'per_page'       => $args['limit'],
 				'offset'         => $args['offset'],
 				'category_slugs' => $categories,
 				'tag_slugs'      => $tags,
 				'_embed'         => true
-			) );
-			//$query = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query );
-			$query = preg_replace( '/%5B[0-9]+%5D/simU', '%5B%5D', $query );
+			) ) );
 
 			// Fetch feed
 			$feed_url = $args['url'] . 'posts?' . $query;


### PR DESCRIPTION
The indexed query parameters are working correctly for array values - i.e. `category_slugs[0]=something&category_slugs[1]=else` - so the additional cleanup is no longer necessary on the query parameters.