### PR TITLE
Story primary category/tag in modern post lists

### DIFF
--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -117,6 +117,44 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 		public static function get_story_topics( $item ) {
 			return self::get_story_terms( $item, 'post_tag' );
 		}
+
+		public static function get_story_primary_section( $item ) {
+			$primary  = null;
+			$sections = self::get_story_sections( $item );
+
+			if ( property_exists( $item, 'primary_category' ) ) {
+				foreach ( $sections as $section ) {
+					if ( $section->id === $item->primary_category ) {
+						$primary = $section;
+						break;
+					}
+				}
+			}
+			else {
+				$primary = $sections[0];
+			}
+
+			return $primary;
+		}
+
+		public static function get_story_primary_topic( $item ) {
+			$primary = null;
+			$topics  = self::get_story_topics( $item );
+
+			if ( property_exists( $item, 'primary_tag' ) ) {
+				foreach ( $topics as $topic ) {
+					if ( $topic->id === $item->primary_tag ) {
+						$primary = $topic;
+						break;
+					}
+				}
+			}
+			else {
+				$primary = $topics[0];
+			}
+
+			return $primary;
+		}
 	}
 
 	add_action( 'wp_enqueue_scripts', array( 'UCF_News_Common', 'add_css' ) );

--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -118,6 +118,14 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 			return self::get_story_terms( $item, 'post_tag' );
 		}
 
+		/**
+		 * Returns the primary section (category) for a given story.
+		 *
+		 * @since 2.1.9
+		 * @author Jo Dickson
+		 * @param object REST API result for a post
+		 * @return mixed Term object, or null
+		 */
 		public static function get_story_primary_section( $item ) {
 			$primary  = null;
 			$sections = self::get_story_sections( $item );
@@ -137,6 +145,14 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 			return $primary;
 		}
 
+		/**
+		 * Returns the primary topic (tag) for a given story.
+		 *
+		 * @since 2.1.9
+		 * @author Jo Dickson
+		 * @param object REST API result for a post
+		 * @return mixed Term object, or null
+		 */
 		public static function get_story_primary_topic( $item ) {
 			$primary = null;
 			$topics  = self::get_story_topics( $item );

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -50,8 +50,7 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 
 		foreach( $items as $item ) :
 			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
-			$sections = UCF_News_Common::get_story_sections( $item );
-			$section = $sections[0];
+			$section = UCF_News_Common::get_story_primary_section( $item );
 	?>
 		<div class="ucf-news-item">
 			<a href="<?php echo $item->link; ?>">
@@ -61,9 +60,11 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 				</div>
 			<?php endif; ?>
 				<div class="ucf-news-item-content">
+					<?php if ( $section ): ?>
 					<div class="ucf-news-section">
 						<span class="ucf-news-section-title"><?php echo $section->name; ?></span>
 					</div>
+					<?php endif; ?>
 					<div class="ucf-news-item-details">
 						<p class="ucf-news-item-title"><?php echo $item->title->rendered; ?></p>
 						<p class="ucf-news-item-excerpt"><?php echo wp_trim_words( $item->excerpt->rendered, 25 ); ?></p>


### PR DESCRIPTION
Added functions for retrieving a single story's primary category (section) and tag (topic), and updated the modern news list layout to utilize it (instead of returning the first available section name).

Resolves #42 ; requires https://github.com/UCF/Today-Utilities/pull/31