### PR TITLE
WP SCIF registration updates

### DIFF
--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -28,16 +28,16 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 						'default'   => 'classic'
 					),
 					array(
-						'name'      => 'Filter by Section ID',
+						'name'      => 'Filter by Section',
 						'param'     => 'sections',
-						'desc'      => 'The section id of each section to filter by',
+						'desc'      => 'Allows you to filter the results by section (category). Enter one ore more comma-separated section slugs.',
 						'type'      => 'text',
 						'default'   => ''
 					),
 					array(
-						'name'      => 'Filter by Topic ID',
+						'name'      => 'Filter by Topic',
 						'param'     => 'topics',
-						'desc'      => 'The topic id of each topic to filter by',
+						'desc'      => 'Allows you to filter the results by topic (tag). Enter one or more comma-separated topic slugs.',
 						'type'      => 'text',
 						'default'   => ''
 					),

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -49,6 +49,13 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 						'default'   => 3
 					),
 					array(
+						'name'      => 'News Item Offset',
+						'param'     => 'offset',
+						'desc'      => 'The number of news items to skip in the feed. For example, set to 1 to skip the first article.',
+						'type'      => 'number',
+						'default'   => 0
+					),
+					array(
 						'name'      => 'Number of News Items Per Row',
 						'param'     => 'per_row',
 						'desc'      => 'The number of news items to show per row (for card layout only)',


### PR DESCRIPTION
- Added missing `offset` param to WP SCIF shortcode registration
- Fixed descriptions for `sections` and `topics` params to note that term slugs are expected (not IDs)

Resolves #29, #41  