### PR TITLE
Added default option for feed_url

### DIFF
--- a/includes/external-stories-shortcode.php
+++ b/includes/external-stories-shortcode.php
@@ -58,7 +58,9 @@ if ( ! class_exists( 'External_Stories_Shortcode' ) ) {
 		}
 
 		public static function sc_external_stories( $attr, $content='' ) {
-			$feed_url = get_option( 'ucf_external_stories_feed_url' );
+			$defaults = UCF_NEWS_Config::$default_plugin_options;
+
+			$feed_url = get_option( 'ucf_external_stories_feed_url', $defaults['ucf_external_stories_feed_url'] );
 
 			$attr = shortcode_atts( array(
 				'title'     => 'In the News',

--- a/includes/external-stories-shortcode.php
+++ b/includes/external-stories-shortcode.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'External_Stories_Shortcode' ) ) {
 		}
 
 		public static function sc_external_stories( $attr, $content='' ) {
-			$defaults = UCF_NEWS_Config::$default_plugin_options;
+			$defaults = UCF_News_Config::$default_plugin_options;
 
 			$feed_url = get_option( 'ucf_external_stories_feed_url', $defaults['ucf_external_stories_feed_url'] );
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Ensures the `ucf_external_stories_feed_url` always has a default value.

**Motivation and Context**
If the shortcode is added to a page before the options page has been saved at least once, a null value was being passed to the feed_url parameter of the feed function. This was causing a URL to be generated that was just query params, i.e. `?limit=3&offset=0`. This change will ensure the first portion of the URL, by default `https://www.ucf.edu/news/wp-json/ucf-news/v1/external-stories/`, always has a value.

**How Has This Been Tested?**
The change can be tested in both DEV and QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
