### PR TITLE
Thumbnail dimensions in img tags

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: ucfwebcom
 Requires at least: 5.3
 Tested up to: 5.3
 Stable tag: 2.2.1
-Requires PHP: 5.4
+Requires PHP: 7.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html
 

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 			$items = array( $items );
 		}
 
-		$per_row = $args['per_row'];
+		$per_row = intval( $args['per_row'] );
 
 		ob_start();
 
@@ -54,7 +54,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 
 		foreach ( $items as $index=>$item ) :
 			$date = date( "M d", strtotime( $item->date ) );
-			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
+			$item_img = UCF_News_Common::get_story_img_tag( $item );
 	?>
 		<?php
 			if( $index !== 0 && ( $index % $per_row ) === 0 ) {
@@ -63,7 +63,10 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 		?>
 		<div class="ucf-news-card">
 			<a class="ucf-news-card-link" href="<?php echo $item->link; ?>">
-				<img src="<?php echo $item_img; ?>" class="ucf-news-thumbnail-image" alt="<?php echo $item->title->rendered; ?>">
+				<?php if ( $item_img ): ?>
+					<?php echo $item_img; ?>
+				<?php endif; ?>
+
 				<div class="ucf-news-card-block">
 					<h3 class="ucf-news-card-title"><?php echo $item->title->rendered; ?></h3>
 					<p class="ucf-news-card-text"><?php echo $date; ?></p>

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -51,14 +51,14 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 	<?php else : ?>
 	<?php
 		foreach( $items as $item ) :
-			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
+			$item_img = UCF_News_Common::get_story_img_tag( $item );
 	?>
 			<div class="ucf-news-item">
-			<?php if ( $item_img ): ?>
+				<?php if ( $item_img ): ?>
 				<div class="ucf-news-thumbnail">
-					<img class="ucf-news-thumbnail-image" src="<?php echo $item_img; ?>" alt="">
+					<?php echo $item_img; ?>
 				</div>
-			<?php endif; ?>
+				<?php endif; ?>
 				<div class="ucf-news-item-title">
 					<a href="<?php echo $item->link; ?>">
 						<?php echo $item->title->rendered; ?>

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -49,16 +49,16 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 	if ( count( $items ) === 0 ) : echo $fallback_message; else :
 
 		foreach( $items as $item ) :
-			$item_img = UCF_News_Common::get_story_image_or_fallback( $item );
+			$item_img = UCF_News_Common::get_story_img_tag( $item );
 			$section = UCF_News_Common::get_story_primary_section( $item );
 	?>
 		<div class="ucf-news-item">
 			<a href="<?php echo $item->link; ?>">
-			<?php if ( $item_img ) : ?>
+				<?php if ( $item_img ) : ?>
 				<div class="ucf-news-thumbnail">
-					<img src="<?php echo $item_img; ?>" class="ucf-news-thumbnail-image" alt="">
+					<?php echo $item_img; ?>
 				</div>
-			<?php endif; ?>
+				<?php endif; ?>
 				<div class="ucf-news-item-content">
 					<?php if ( $section ): ?>
 					<div class="ucf-news-section">


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a new function, `UCF_News_Common::get_story_img_tag()`, that returns an HTML string for a news article's thumbnail `<img>`.  This function returns a tag with `width` and `height` attributes applied that represent the dimensions of the thumbnail at the image size it was retrieved at (e.g. "thumbnail"/"small"/"medium"...)

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added to help improve frontend performance and reduce layout shift on page load.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev in latest Chrome, Chromium Edge, IE, FF and Safari.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
