### PR TITLE
Added option to remove image from the card layout

### DIFF
--- a/includes/ucf-news-config.php
+++ b/includes/ucf-news-config.php
@@ -12,6 +12,7 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 				'topics'    => '',
 				'limit'     => 3,
 				'per_row'   => 3,
+				'show_img'  => true,
 				'offset'    => 0
 			),
 			$default_plugin_options = array(
@@ -101,6 +102,7 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 						$list[$key] = intval( $val );
 						break;
 					case 'ucf_news_include_css':
+					case 'show_img':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
 						break;
 					default:

--- a/includes/ucf-news-config.php
+++ b/includes/ucf-news-config.php
@@ -6,14 +6,14 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 	class UCF_News_Config {
 		public static
 			$default_options = array(
-				'title'     => 'News',
-				'layout'    => 'classic',
-				'sections'  => '',
-				'topics'    => '',
-				'limit'     => 3,
-				'per_row'   => 3,
-				'show_img'  => true,
-				'offset'    => 0
+				'title'      => 'News',
+				'layout'     => 'classic',
+				'sections'   => '',
+				'topics'     => '',
+				'limit'      => 3,
+				'per_row'    => 3,
+				'show_image' => true,
+				'offset'     => 0
 			),
 			$default_plugin_options = array(
 				'ucf_news_feed_url'             => 'https://www.ucf.edu/news/wp-json/wp/v2/',
@@ -102,7 +102,7 @@ if ( ! class_exists( 'UCF_News_Config' ) ) {
 						$list[$key] = intval( $val );
 						break;
 					case 'ucf_news_include_css':
-					case 'show_img':
+					case 'show_image':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
 						break;
 					default:

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -94,6 +94,7 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 				'offset'    => 0,
 				'limit'     => 3,
 				'per_row'   => 3,
+				'show_img'  => true,
 				'feed_url'  => ''
 			), $attr );
 

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -87,15 +87,15 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 
 		public static function sc_ucf_news_feed( $attr, $content='' ) {
 			$attr = shortcode_atts( array(
-				'title'     => 'News',
-				'layout'    => 'classic',
-				'sections'  => '',
-				'topics'    => '',
-				'offset'    => 0,
-				'limit'     => 3,
-				'per_row'   => 3,
-				'show_img'  => true,
-				'feed_url'  => ''
+				'title'      => 'News',
+				'layout'     => 'classic',
+				'sections'   => '',
+				'topics'     => '',
+				'offset'     => 0,
+				'limit'      => 3,
+				'per_row'    => 3,
+				'show_image' => true,
+				'feed_url'   => ''
 			), $attr );
 
 			$title    = $attr['title'];

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -45,6 +45,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 		}
 
 		$per_row = intval( $args['per_row'] );
+		$show_img = filter_var( $args['show_img'], FILTER_VALIDATE_BOOLEAN );
 
 		ob_start();
 
@@ -63,7 +64,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 		?>
 		<div class="ucf-news-card">
 			<a class="ucf-news-card-link" href="<?php echo $item->link; ?>">
-				<?php if ( $item_img ): ?>
+				<?php if ( $item_img && $show_img ): ?>
 					<?php echo $item_img; ?>
 				<?php endif; ?>
 

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -45,7 +45,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 		}
 
 		$per_row = intval( $args['per_row'] );
-		$show_img = filter_var( $args['show_img'], FILTER_VALIDATE_BOOLEAN );
+		$show_image = filter_var( $args['show_image'], FILTER_VALIDATE_BOOLEAN );
 
 		ob_start();
 
@@ -64,7 +64,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 		?>
 		<div class="ucf-news-card">
 			<a class="ucf-news-card-link" href="<?php echo $item->link; ?>">
-				<?php if ( $item_img && $show_img ): ?>
+				<?php if ( $item_img && $show_image ): ?>
 					<?php echo $item_img; ?>
 				<?php endif; ?>
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a `show_img` parameter to the `ucf-news-feed` shortcode. This parameter is made to be used with the `card` layout, and will remove the image from the card when set to `false`. The default value is `true` for backwards compatibility.

**Motivation and Context**
We needed to be able to display news stories in a compact, card layout with the story images.

**How Has This Been Tested?**
Changes are available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
