### PR TITLE
Filter news by search query; other news-retrieval improvements

### DIFF
--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -52,10 +52,11 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 				'offset'         => isset( $args['offset'] ) ? (int) $args['offset'] : 0,
 				'category_slugs' => isset( $args['sections'] ) ? self::format_tax_arg( $args['sections'] ) : null,
 				'tag_slugs'      => isset( $args['topics'] ) ? self::format_tax_arg( $args['topics'] ) : null,
+				'search'         => $args['search'] ?? null,
 				'_embed'         => true
 			), array( 'UCF_News_Feed', 'non_empty_allow_zero' ) );
 
-			$query = urldecode( http_build_query( $query_args ) );
+			$query = http_build_query( $query_args );
 
 			// Fetch feed
 			if ( $custom_feed_url === false ) {

--- a/includes/ucf-news-feed.php
+++ b/includes/ucf-news-feed.php
@@ -21,10 +21,16 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 			return $result;
 		}
 
-		public static function format_tax_arg( $terms, $tax ) {
-			$terms_filtered = is_array( $terms ) ? array_filter( $terms ) : null;
+		public static function format_tax_arg( $terms, $tax=null ) {
+			if ( is_string( $terms ) ) {
+				$terms = array_map( 'trim', explode( ',', $terms ) );
+			}
 
-			return $terms_filtered;
+			if ( is_array( $terms ) ) {
+				$terms = array_filter( $terms );
+			}
+
+			return is_array( $terms ) && ! empty( $terms ) ? $terms : null;
 		}
 
 		public static function non_empty_allow_zero( $arg ) {
@@ -36,51 +42,30 @@ if ( ! class_exists( 'UCF_News_Feed' ) ) {
 		}
 
 		public static function get_news_items( $args ) {
-			$url_override = get_option( 'ucf_news_feed_url' );
-			$custom_url   = false;
+			$custom_feed_url  = isset( $args['feed_url'] ) && ! empty( $args['feed_url'] ) ? $args['feed_url'] : false;
+			$default_feed_url = get_option( 'ucf_news_feed_url' ) ?: UCF_News_Config::$default_plugin_options['ucf_news_feed_url'];
+			$feed_url         = $custom_feed_url ?: $default_feed_url;
 
-			if ( ! empty( $args['feed_url'] ) ) {
-				$url_override = $args['feed_url'];
-				$custom_url = true;
-			}
-
-			$args = array(
-				'url'        => $url_override ? $url_override : UCF_News_Config::$default_plugin_options['ucf_news_feed_url'],
-				'limit'      => isset( $args['limit'] ) ? (int) $args['limit'] : 3,
-				'offset'     => isset( $args['offset'] ) ? (int) $args['offset'] : 0,
-				'categories' => isset( $args['sections'] ) ? array_map( 'trim', explode( ',', $args['sections'] ) ) : null,
-				'tags'       => isset( $args['topics'] ) ? array_map( 'trim', explode( ',', $args['topics'] ) ) : null,
-			);
-
-			// Empty array of indexes with no value.
-			$args = array_filter( $args, array( 'UCF_News_Feed', 'non_empty_allow_zero' ) );
-
-			// Set up query params.
-			$categories = $tags = array();
-
-			if ( isset( $args['categories'] ) ) {
-				$categories = self::format_tax_arg( $args['categories'], 'category_slugs' );
-			}
-			if ( isset( $args['tags'] ) ) {
-				$tags = self::format_tax_arg( $args['tags'], 'tag_slugs' );
-			}
-
-			$query = urldecode( http_build_query( array(
-				'per_page'       => $args['limit'],
-				'offset'         => $args['offset'],
-				'category_slugs' => $categories,
-				'tag_slugs'      => $tags,
+			// Set up query params
+			$query_args = array_filter( array(
+				'per_page'       => isset( $args['limit'] ) ? (int) $args['limit'] : 3,
+				'offset'         => isset( $args['offset'] ) ? (int) $args['offset'] : 0,
+				'category_slugs' => isset( $args['sections'] ) ? self::format_tax_arg( $args['sections'] ) : null,
+				'tag_slugs'      => isset( $args['topics'] ) ? self::format_tax_arg( $args['topics'] ) : null,
 				'_embed'         => true
-			) ) );
+			), array( 'UCF_News_Feed', 'non_empty_allow_zero' ) );
+
+			$query = urldecode( http_build_query( $query_args ) );
 
 			// Fetch feed
-			$feed_url = $args['url'];
-
-			if ( $custom_url === false ) {
+			if ( $custom_feed_url === false ) {
 				$feed_url .= 'posts';
 			}
 
-			$feed_url .=  '?' . $query;
+			if ( $query ) {
+				$feed_url .= strpos( $feed_url, '?' ) !== false ? '&' : '?';
+				$feed_url .= $query;
+			}
 
 			return self::get_json_feed( $feed_url );
 		}

--- a/includes/ucf-news-shortcode.php
+++ b/includes/ucf-news-shortcode.php
@@ -42,6 +42,13 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 						'default'   => ''
 					),
 					array(
+						'name'      => 'Filter by Search Query',
+						'param'     => 'search',
+						'desc'      => 'Allows you to filter the results via a search query.',
+						'type'      => 'text',
+						'default'   => ''
+					),
+					array(
 						'name'      => 'Number of News Items',
 						'param'     => 'limit',
 						'desc'      => 'The number of news items to show',
@@ -91,6 +98,7 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 				'layout'     => 'classic',
 				'sections'   => '',
 				'topics'     => '',
+				'search'     => '',
 				'offset'     => 0,
 				'limit'      => 3,
 				'per_row'    => 3,
@@ -98,14 +106,13 @@ if ( ! class_exists( 'UCF_News_Shortcode' ) ) {
 				'feed_url'   => ''
 			), $attr );
 
-			$title    = $attr['title'];
-			$layout   = $attr['layout'];
-			$per_row  = $attr['per_row'];
+			$layout = $attr['layout'];
 
 			$args = array(
 				'feed_url' => $attr['feed_url'],
 				'sections' => $attr['sections'] ?: null,
 				'topics'   => $attr['topics'] ?: null,
+				'search'   => $attr['search'] ?: null,
 				'offset'   => $attr['offset'] ? (int) $attr['offset'] : 0,
 				'limit'    => $attr['limit'] ? (int) $attr['limit'] : 3
 			);

--- a/includes/ucf-news-widget.php
+++ b/includes/ucf-news-widget.php
@@ -49,6 +49,7 @@ if ( ! class_exists( 'UCF_News_Widget' ) ) {
 			$layout = $options['layout'];
 			$sections = $options['sections'];
 			$topics = $options['topics'];
+			$search = $options['search'];
 			$limit = $options['limit'];
 			$offset = $options['offset'];
 			$per_row = $options['per_row'];
@@ -73,6 +74,10 @@ if ( ! class_exists( 'UCF_News_Widget' ) ) {
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'topics' ) ); ?>"><?php echo __( 'Filter by topics' ); ?></label>
 				<input class="widefat topic-input" id="<?php echo esc_attr( $this->get_field_id( 'topics' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'topics' ) ); ?>" type="text" value="<?php echo esc_attr( $topics ); ?>" >
+			</p>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'search' ) ); ?>"><?php echo __( 'Filter by search query' ); ?></label>
+				<input class="widefat topic-input" id="<?php echo esc_attr( $this->get_field_id( 'search' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'search' ) ); ?>" type="text" value="<?php echo esc_attr( $search ); ?>" >
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>"><?php echo __( 'Limit results' ); ?></label>


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added new `search` arg for the `[ucf-news-feed]` shortcode, which allows you to filter results by a search query.
- Tidied up `UCF_News_Feed::get_news_items()` and adjusted `UCF_News_Feed::format_tax_arg()` a bit to omit unset/empty query args from the final feed URL that's requested, and support custom feed URLs that already include query args.

Note: this update removes the `urldecode()`-ing on the generated query arg string (https://github.com/UCF/UCF-News-Plugin/compare/rc-v2.3.3...optional-cat-tag-slugs?expand=1#diff-2b633afd9766c746e0229a2cfad35d6b67f6f32b91b77dd9e186357770adb851R59) to ensure search queries are properly encoded--I assume this was initially added to prevent section/topic array keys from being encoded, but they seem to still be interpreted correctly after removing it, so 🤷 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We will need this for the new faculty profiles on main site, but they're still nice updates to have regardless.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
