### PR TITLE
News thumbnail fix for stories with poster thumbnails

### DIFF
--- a/includes/ucf-news-common.php
+++ b/includes/ucf-news-common.php
@@ -148,17 +148,19 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 			if ( $thumbnail ) {
 				$img_url = $thumbnail;
 
-				// Try to sniff for img dim's in featured
-				// image metadata:
-				if ( $return_details && is_array( $featured_media ) ) {
+				if ( $return_details ) {
 					$img_details[0] = $img_url;
-					$img_obj = $featured_media[0];
-					if ( isset( $img_obj->media_details->sizes ) ) {
-						foreach ( (array) $img_obj->media_details->sizes as $size ) {
-							if ( $size->source_url === $img_url ) {
-								$img_details[1] = $size->width ?? '';
-								$img_details[2] = $size->height ?? '';
-								break;
+					if ( is_array( $featured_media ) ) {
+						// Try to sniff for img dim's in featured
+						// image metadata:
+						$img_obj = $featured_media[0];
+						if ( isset( $img_obj->media_details->sizes ) ) {
+							foreach ( (array) $img_obj->media_details->sizes as $size ) {
+								if ( $size->source_url === $img_url ) {
+									$img_details[1] = $size->width ?? '';
+									$img_details[2] = $size->height ?? '';
+									break;
+								}
 							}
 						}
 					}
@@ -204,7 +206,13 @@ if ( ! class_exists( 'UCF_News_Common' ) ) {
 
 			ob_start();
 		?>
-			<img src="<?php echo $img_details[0]; ?>" class="<?php echo $css_class; ?>" alt="" width="<?php echo $img_details[1]; ?>" height="<?php echo $img_details[2]; ?>">
+			<img
+				src="<?php echo $img_details[0]; ?>"
+				class="<?php echo $css_class; ?>"
+				alt=""
+				<?php if ( $img_details[1] ) { ?>width="<?php echo $img_details[1]; ?>"<?php } ?>
+				<?php if ( $img_details[2] ) { ?>height="<?php echo $img_details[2]; ?>"<?php } ?>
+			>
 		<?php
 			return trim( ob_get_clean() );
 		}

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -57,7 +57,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 			<?php
 			foreach ( $items as $index => $item ) :
 				$date = date( "M d", strtotime( $item->date ) );
-				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid w-md-100' );
+				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid w-100' );
 
 				// Try to use precise column sizes where we can to
 				// prevent undesirable column overflow in small containers

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 			echo '<div class="ucf-news-error">' . $fallback_message . '</div>';
 		else :
 			foreach ( $items as $item ) :
-				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid' );
+				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid w-100' );
 	?>
 
 				<div class="ucf-news-item media position-relative mb-4">

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -51,7 +51,7 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 		else :
 
 			foreach ( $items as $item ) :
-				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid' );
+				$item_img = UCF_News_Common::get_story_img_tag( $item, 'ucf-news-thumbnail-image img-fluid w-100' );
 				$section = UCF_News_Common::get_story_primary_section( $item );
 	?>
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated `UCF_News_Common::get_story_image_or_fallback()` to at least return a thumbnail URL when one is found, even if no thumbnail dimensions can be determined, if `$return_details` is `true`.
- Because we're now displaying some thumbnails without explicit `width` and `height` attributes, `w-100`  has been added to each layout's thumbnail to look decent in IE11.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue where Today stories with a video header (and, therefore, an oembed poster as a thumbnail) would never display a thumbnail in [ucf-news-feed] layouts (because we don't have access to oembed poster dimensions).

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev against latest 2 versions of supported browsers.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
