### PR TITLE
Link style adjustments

### DIFF
--- a/layouts/external-stories-classic.php
+++ b/layouts/external-stories-classic.php
@@ -38,13 +38,12 @@ if ( ! function_exists( 'ucf_external_stories_classic_content' ) ) {
 		foreach( $items as $item ) :
 	?>
 		<article class="mb-3">
-			<a href="<?php echo $item->url; ?>" target="_blank" rel="nofollow">
-				<h3 class="h6 text-secondary external-story-title"><?php echo $item->title; ?></h3>
+			<a class="text-secondary text-decoration-none hover-text-underline" href="<?php echo $item->url; ?>" target="_blank" rel="nofollow">
+				<h3 class="h6 external-story-title"><?php echo $item->title; ?></h3>
 			</a>
-			<cite class="external-story-source text-muted text-small">
+			<cite class="external-story-source text-muted font-size-sm">
 				<?php echo $item->source; ?>
 			</cite>
-
 		</article>
 	<?php
 		endforeach;

--- a/layouts/ucf-news-card.php
+++ b/layouts/ucf-news-card.php
@@ -69,7 +69,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 				}
 			?>
 				<div class="ucf-news-item <?php echo $item_col_class; ?> mb-4 pb-lg-2">
-					<div class="ucf-news-card card h-lg-100" style="background-color: transparent; border-color: rgba(118, 118, 118, .25);">
+					<div class="ucf-news-card card h-lg-100 hover-parent" style="background-color: transparent; border-color: rgba(118, 118, 118, .25);">
 						<div class="row no-gutters">
 							<?php if ( $item_img && $show_image ): ?>
 							<div class="ucf-news-thumbnail col-4 col-md-3 col-lg-12 py-3 pl-3 p-lg-0">
@@ -78,7 +78,7 @@ if ( ! function_exists( 'ucf_news_display_card' ) ) {
 							<?php endif; ?>
 							<div class="col col-lg-12 position-static">
 								<div class="ucf-news-item-content card-block">
-									<a class="ucf-news-item-title card-title stretched-link d-block font-weight-bold mb-0 line-height-3" href="<?php echo $item->link; ?>" style="color: inherit;">
+									<a class="ucf-news-item-title card-title stretched-link text-decoration-none hover-child-text-underline d-block font-weight-bold mb-0 line-height-3" href="<?php echo $item->link; ?>" style="color: inherit;">
 										<?php echo $item->title->rendered; ?>
 									</a>
 								</div>

--- a/layouts/ucf-news-classic.php
+++ b/layouts/ucf-news-classic.php
@@ -61,7 +61,7 @@ if ( ! function_exists( 'ucf_news_display_classic' ) ) {
 					<?php endif; ?>
 					<div class="ucf-news-item-content media-body">
 						<div class="ucf-news-item-details line-height-4">
-							<a class="ucf-news-item-title stretched-link" href="<?php echo $item->link; ?>" style="color: inherit;">
+							<a class="ucf-news-item-title stretched-link font-weight-bold text-decoration-none hover-text-underline" href="<?php echo $item->link; ?>" style="color: inherit;">
 								<?php echo $item->title->rendered; ?>
 							</a>
 						</div>

--- a/layouts/ucf-news-modern.php
+++ b/layouts/ucf-news-modern.php
@@ -72,7 +72,7 @@ if ( ! function_exists( 'ucf_news_display_modern' ) ) {
 						<?php endif; ?>
 
 						<div class="ucf-news-item-details">
-							<a class="ucf-news-item-title d-block stretched-link h5 mb-2 pb-1" href="<?php echo $item->link; ?>" style="color: inherit;">
+							<a class="ucf-news-item-title d-block stretched-link text-decoration-none h5 mb-2 pb-1" href="<?php echo $item->link; ?>" style="color: inherit;">
 								<?php echo $item->title->rendered; ?>
 							</a>
 							<div class="ucf-news-item-excerpt font-size-sm">


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-News-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-News-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Unsets underline styles on news item links to reduce visual clutter after upgrading to Athena v1.1.1.  Adds underlines on hover/focus where there are no other visual differences in those states.
- Replaced usage of nonexistent `.text-small` class in external stories default layout with `.font-size-sm`

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #76 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
